### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools
+    - versioneer
   run:
     - attrs
     - corner
@@ -35,6 +36,8 @@ requirements:
     - python-lalpulsar >=6.0
     - scipy
     - tqdm
+    - lalsuite
+    
 
 test:
   requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Hi, I am trying to put the pyhough package on conda forge, but I receive the following [error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1255461&view=logs&j=4cabe686-70ae-553a-7fd0-310379f2cbac&t=6a4fc7c9-c31a-5115-eff9-6479d72b69ff) during the builds on different operating systems, which relates to dependences of pyfstat, in particular

`pyfstat 2.2.1 requires lalsuite, which is not installed.`
`pyfstat 2.2.1 requires versioneer, which is not installed.`

So, I've updated the meta.yaml file of pyfstat, in the hopes that once this is updated, pyhough will build


<!--
Please add any other relevant info below:
-->
